### PR TITLE
docs(openapi): align GET /models examples and parameter semantics

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5018,7 +5018,7 @@ paths:
         - in: query
           name: provider
           required: false
-          description: Filter models by virtual key slug (the provider segment in model id `@provider/model`).
+          description: Filter models by model catalog provider slug (the provider segment in model id `@provider/model`).
           schema:
             type: string
         - in: query
@@ -5036,7 +5036,7 @@ paths:
         - in: query
           name: sort
           required: false
-          description: The field to sort the results by (`provider` sorts by virtual key slug).
+          description: The field to sort the results by (`provider` sorts by model catalog provider slug).
           schema:
             type: string
             enum: [name, provider, ai_service]
@@ -5077,7 +5077,7 @@ paths:
           label: Self-Hosted
           source: |
             # Example of sending a query parameter in the URL
-            curl 'https://YOUR_SELF_HOSTED_URL/models?ai_service=openai' \
+            curl 'https://SELF_HOSTED_GATEWAY_URL/models?ai_service=openai' \
               -H "x-portkey-api-key: $PORTKEY_API_KEY"
         - lang: python
           label: Default
@@ -5100,7 +5100,7 @@ paths:
 
             client = Portkey(
               api_key = "PORTKEY_API_KEY",
-              base_url = "https://YOUR_SELF_HOSTED_URL"
+              base_url = "https://SELF_HOSTED_GATEWAY_URL"
             )
 
             # Example of sending query parameters via extra_query
@@ -5132,7 +5132,7 @@ paths:
 
             const client = new Portkey({
               apiKey: 'PORTKEY_API_KEY',
-              baseUrl: 'https://YOUR_SELF_HOSTED_URL'
+              baseUrl: 'https://SELF_HOSTED_GATEWAY_URL'
             });
 
             async function main() {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5012,31 +5012,31 @@ paths:
         - in: query
           name: ai_service
           required: false
-          description: Filter models by the AI service (e.g., 'openai', 'anthropic').
+          description: Filter models by AI service (e.g., 'openai', 'anthropic').
           schema:
             type: string
         - in: query
           name: provider
           required: false
-          description: Filter models by the provider.
+          description: Filter models by virtual key slug (the provider segment in model id `@provider/model`).
           schema:
             type: string
         - in: query
           name: limit
           required: false
-          description: The maximum number of models to return.
+          description: Maximum number of models to return per page.
           schema:
             type: integer
         - in: query
           name: offset
           required: false
-          description: The number of models to skip before starting to collect the result set.
+          description: Number of models to skip before collecting the result set.
           schema:
             type: integer
         - in: query
           name: sort
           required: false
-          description: The field to sort the results by.
+          description: The field to sort the results by (`provider` sorts by virtual key slug).
           schema:
             type: string
             enum: [name, provider, ai_service]
@@ -5071,13 +5071,13 @@ paths:
           label: Default
           source: |
             # Example of sending a query parameter in the URL
-            curl 'https://api.portkey.ai/v1/models?provider=openai' \
+            curl 'https://api.portkey.ai/v1/models?ai_service=openai' \
               -H "x-portkey-api-key: $PORTKEY_API_KEY"
         - lang: curl
           label: Self-Hosted
           source: |
             # Example of sending a query parameter in the URL
-            curl 'https://YOUR_SELF_HOSTED_URL/models?provider=openai' \
+            curl 'https://YOUR_SELF_HOSTED_URL/models?ai_service=openai' \
               -H "x-portkey-api-key: $PORTKEY_API_KEY"
         - lang: python
           label: Default
@@ -5090,7 +5090,7 @@ paths:
 
             # Example of sending query parameters via extra_query
             models = client.models.list(
-              extra_query={"provider": "openai"}
+              extra_query={"ai_service": "openai"}
             )
             print(models)
         - lang: python
@@ -5105,7 +5105,7 @@ paths:
 
             # Example of sending query parameters via extra_query
             models = client.models.list(
-              extra_query={"provider": "openai"}
+              extra_query={"ai_service": "openai"}
             )
             print(models)
         - lang: javascript
@@ -5120,7 +5120,7 @@ paths:
             async function main() {
               // Example of sending query parameters in the list method
               const list = await client.models.list({
-                provider: "openai"
+                ai_service: "openai"
               });
               console.log(list);
             }
@@ -5138,7 +5138,7 @@ paths:
             async function main() {
               // Example of sending query parameters in the list method
               const list = await client.models.list({
-                provider: "openai"
+                ai_service: "openai"
               });
               console.log(list);
             }


### PR DESCRIPTION
## Description
This PR updates the OpenAPI spec for `GET /models` to match the current models API behavior and avoid confusion in generated docs/examples.

### What changed
- Updated `x-code-samples` to use `ai_service=openai` instead of `provider=openai`:
  - cURL (default + self-hosted)
  - Python SDK examples (`extra_query`)
  - JavaScript SDK examples (`client.models.list`)
- Clarified query parameter descriptions:
  - `ai_service`: AI service(e.g. `openai`, `anthropic`)
  - `provider`: virtual key slug (provider segment in `@provider/model`)
  - `limit`: maximum models returned per page/request
  - `offset`: number of models to skip before collecting results
  - `sort`: clarified that `provider` sort refers to virtual key slug

### Why
The previous docs examples implied filtering with `provider=openai`, which conflicted with intended semantics and caused implementation/documentation mismatch. This update ensures docs and API behavior stay consistent and reduces integration errors for users.

### Validation
- Verified `GET /models` parameter block and all code samples render with updated query params.
- Confirmed examples are consistent with current backend contract for models endpoint filtering and pagination semantics.