### PR TITLE
Enhance OpenAPI schema for MCP integrations

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -32678,6 +32678,7 @@ components:
             The field on the entity to populate from the secret reference. Must be unique within the array.
             - **Integrations**: `key` or `configurations.<field>` (e.g. `configurations.aws_secret_access_key`)
             - **Virtual Keys**: `key` or `model_config.<field>` (e.g. `model_config.awsSecretAccessKey`)
+            - **MCP Integrations**: `configurations.<field>` (e.g. `configurations.oauth_metadata`)
           example: "key"
         secret_reference_id:
           type: string
@@ -32687,6 +32688,17 @@ components:
           type: string
           nullable: true
           description: Override the secret_key defined on the secret reference. Use to pick a specific key from a multi-value secret.
+        value_format:
+          type: string
+          nullable: true
+          enum:
+            - json
+            - string
+          description: |
+            Format of the secret value.
+            - `string`: The secret value is treated as a plain string.
+            - `json`: The secret value is parsed as JSON before being applied to the target field. Use this when the target field expects a structured object (e.g. `configurations.oauth_metadata`).
+          example: "json"
 
     CreateSecretReferenceRequest:
       type: object
@@ -36977,6 +36989,11 @@ components:
           enum:
             - http
             - sse
+        secret_mappings:
+          type: array
+          items:
+            $ref: '#/components/schemas/SecretMapping'
+          description: Dynamically resolve secrets from secret references at runtime. Valid target_field values are "configurations.<field>" (e.g. "configurations.oauth_metadata"). Each target_field must be unique.
 
     McpIntegrationCreateResponse:
       type: object
@@ -37041,6 +37058,11 @@ components:
           enum:
             - workspace
             - organisation
+        secret_mappings:
+          type: array
+          items:
+            $ref: '#/components/schemas/SecretMapping'
+          description: Secret reference mappings for this MCP integration. Valid target_field values are "configurations.<field>".
 
     McpIntegrationListItem:
       type: object
@@ -37093,6 +37115,11 @@ components:
         workspaces_count: 
           type: number
           nullable: true
+        secret_mappings:
+          type: array
+          items:
+            $ref: '#/components/schemas/SecretMapping'
+          description: Secret reference mappings for this MCP integration. Valid target_field values are "configurations.<field>".
 
     McpIntegrationListResponse:
       type: object
@@ -37152,6 +37179,11 @@ components:
           enum:
             - http
             - sse
+        secret_mappings:
+          type: array
+          items:
+            $ref: '#/components/schemas/SecretMapping'
+          description: Dynamically resolve secrets from secret references at runtime. Valid target_field values are "configurations.<field>" (e.g. "configurations.oauth_metadata"). Each target_field must be unique.
 
     McpIntegrationWorkspaceItem:
       type: object


### PR DESCRIPTION
- Added support for secret mappings in MCP integration requests and responses, allowing dynamic resolution of secrets from secret references.
- Introduced a new value_format field to specify the format of secret values (string or json) for better handling of structured objects.