### PR TITLE
fix: align workspace id and slug response examples

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14977,6 +14977,17 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Workspace"
+              example:
+                id: "2f4f5b8f-6d12-447a-b4b2-e3e5f28380a7"
+                slug: "ws-workspace-name-0909"
+                name: "WORKSPACE_NAME_0909"
+                description: "WORKSPACE_DESCRIPTION"
+                created_at: "2026-05-27T05:36:01.987Z"
+                last_updated_at: "2026-05-27T05:36:01.987Z"
+                defaults:
+                  metadata:
+                    environment: production
+                    foo: bar
       x-code-samples:
         - lang: python
           label: Default
@@ -15151,13 +15162,15 @@ paths:
                 total: 2
                 object: list
                 data:
-                  - id: test-prod-ws-12345
+                  - id: "2f4f5b8f-6d12-447a-b4b2-e3e5f28380a7"
+                    slug: "ws-test-prod-12345"
                     name: Test prod workspace
                     description: This is a production workspace
                     created_at: "2023-07-13 13:51:27"
                     last_updated_at: "2023-07-13 14:51:27"
                     object: workspace
-                  - id: test-prod-ws-12345
+                  - id: "a03ced4b-95d0-4d6a-92db-2c7af6df8e53"
+                    slug: "ws-test-stage-12345"
                     name: Test prod workspace
                     description: This is a production workspace
                     created_at: "2023-07-13 13:51:27"
@@ -15277,6 +15290,7 @@ paths:
           schema:
             type: string
           required: true
+          description: Workspace UUID. Workspace slug is also accepted for backward compatibility.
       responses:
         "200":
           description: OK
@@ -15408,6 +15422,19 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WorkspaceWithUsers"
+              example:
+                id: "2f4f5b8f-6d12-447a-b4b2-e3e5f28380a7"
+                slug: "ws-test-a-174eb1"
+                name: "New Workspace"
+                description: null
+                created_at: "2026-07-30T13:27:29.000Z"
+                last_updated_at: "2024-07-30T13:27:29.000Z"
+                defaults:
+                  metadata:
+                    foo: bar
+                users: []
+                usage_limits: []
+                rate_limits: []
       x-code-samples:
         - lang: python
           label: Default
@@ -15421,7 +15448,7 @@ paths:
 
             # Get workspace details
             workspace = portkey.admin.workspaces.retrieve(
-                workspace_id='WORKSPACE_SLUG'
+                workspace_id='WORKSPACE_ID'
             )
 
             print(workspace)
@@ -15435,7 +15462,7 @@ paths:
             })
 
             const workspace=await portkey.admin.workspaces.retrieve({
-                workspaceId: 'WORKSPACE_SLUG',
+                workspaceId: 'WORKSPACE_ID',
             })
             console.log(workspace);
         - lang: curl
@@ -15461,7 +15488,7 @@ paths:
 
             # Get workspace details
             workspace = portkey.admin.workspaces.retrieve(
-                workspace_id='WORKSPACE_SLUG'
+                workspace_id='WORKSPACE_ID'
             )
 
             print(workspace)
@@ -15476,7 +15503,7 @@ paths:
             })
 
             const workspace=await portkey.admin.workspaces.retrieve({
-                workspaceId: 'WORKSPACE_SLUG',
+                workspaceId: 'WORKSPACE_ID',
             })
             console.log(workspace);
 
@@ -15490,6 +15517,7 @@ paths:
           schema:
             type: string
           required: true
+          description: Workspace UUID. Workspace slug is also accepted for backward compatibility.
       responses:
         "200":
           description: OK
@@ -15506,7 +15534,7 @@ paths:
 
             # Delete workspace
             result = portkey.admin.workspaces.delete(
-                workspace_id='WORKSPACE_SLUG'
+                workspace_id='WORKSPACE_ID'
             )
 
             print(result)
@@ -15520,7 +15548,7 @@ paths:
             })
 
             const workspace=await portkey.admin.workspaces.delete({
-                workspaceId: 'WORKSPACE_SLUG',
+                workspaceId: 'WORKSPACE_ID',
             })
             console.log(workspace);
         - lang: curl
@@ -15546,7 +15574,7 @@ paths:
 
             # Delete workspace
             result = portkey.admin.workspaces.delete(
-                workspace_id='WORKSPACE_SLUG'
+                workspace_id='WORKSPACE_ID'
             )
 
             print(result)
@@ -15561,7 +15589,7 @@ paths:
             })
 
             const workspace=await portkey.admin.workspaces.delete({
-                workspaceId: 'WORKSPACE_SLUG',
+                workspaceId: 'WORKSPACE_ID',
             })
             console.log(workspace);
 
@@ -33540,9 +33568,12 @@ components:
       properties:
         id:
           type: string
-          example: ws-test-a-174eb1
+          format: uuid
+          description: Unique workspace UUID.
+          example: "2f4f5b8f-6d12-447a-b4b2-e3e5f28380a7"
         slug:
           type: string
+          description: Workspace slug identifier.
           example: ws-test-a-174eb1
         name:
           type: string
@@ -33605,9 +33636,12 @@ components:
       properties:
         id:
           type: string
-          example: ws-test-a-174eb1
+          format: uuid
+          description: Unique workspace UUID.
+          example: "2f4f5b8f-6d12-447a-b4b2-e3e5f28380a7"
         slug:
           type: string
+          description: Workspace slug identifier.
           example: ws-test-a-174eb1
         name:
           type: string


### PR DESCRIPTION
## Summary
- update workspace response examples to clearly separate UUID `id` from workspace `slug`
- add an explicit retrieve-workspace 200 example with distinct `id` and `slug`
- keep changes limited to OpenAPI spec examples/documentation fields

## Test plan
- [x] Verify `Workspace` and `WorkspaceWithUsers` examples use UUID for `id`
- [x] Verify create/retrieve workspace response examples no longer show same value for `id` and `slug`
- [x] Confirm diff scope is only `openapi.yaml`