### PR TITLE
Document usage limits policy reset fields in OpenAPI spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -36740,6 +36740,22 @@ components:
           nullable: true
           enum: [monthly, weekly]
           description: Reset period
+        periodic_reset_days:
+          type: integer
+          nullable: true
+          minimum: 1
+          maximum: 365
+          description: Reset the usage counter every N days (1-365). Mutually exclusive with periodic_reset.
+        next_usage_reset_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: ISO 8601 datetime for the next scheduled usage reset. Populated for periodic_reset_days policies.
+        last_reset_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: ISO 8601 datetime of the last usage reset.
         status:
           type: string
           enum: [active, archived]


### PR DESCRIPTION
## Summary

Updates the OpenAPI spec to match what the usage limits **list** and **get** APIs already return.

Related backend fix: [albus#2165](https://github.com/Portkey-AI/albus/pull/2165) — list now returns the same policy fields as get by passing optional `select` in the list controller.

## What changed

Added three missing fields to `UsageLimitsPolicy` in `openapi.yaml`:

- `periodic_reset_days`
- `next_usage_reset_at`
- `last_reset_at`

List and get both use this schema, but these reset-related fields were returned by the API and not documented.

## Note

These fields can be `null` for policies using `periodic_reset: monthly` or `weekly`. That is expected — they mainly apply to `periodic_reset_days` policies. List and get behave the same here.

## Test plan

- [ ] Check `GET /policies/usage-limits` docs show the three new fields on list items
- [ ] Check `GET /policies/usage-limits/{policyUsageLimitsId}` docs show the same fields
- [ ] Merge with [albus#2165](https://github.com/Portkey-AI/albus/pull/2165)

Made with [Cursor](https://cursor.com)