### PR TITLE
docs: add requestParametersCheck example to POST /guardrails OpenAPI …

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2317,6 +2317,31 @@ paths:
                     onFail: "block"
                     message: "Required metadata missing"
 
+              request_parameters_check:
+                summary: "[BASIC] Request Parameters Check"
+                value:
+                  name: "Request Parameters Guard"
+                  workspace_id: "550e8400-e29b-41d4-a716-446655440000"
+                  checks:
+                    - id: "default.requestParametersCheck"
+                      parameters:
+                        tools:
+                          allowedTypes: ["function"]
+                          blockedFunctionNames: ["executeShell", "dropTable"]
+                        params:
+                          blockedKeys: ["logit_bias", "seed"]
+                          allowedKeys: ["model", "messages", "temperature", "max_tokens"]
+                          values:
+                            model:
+                              allowedValues: ["gpt-4o", "gpt-4o-mini"]
+                            stream:
+                              blockedValues: [true]
+                            max_tokens:
+                              allowedValues: [256, 512, 1024, 2048]
+                  actions:
+                    on_fail: "deny"
+                    on_success: "continue"
+
               # PRO CATEGORY EXAMPLES
               portkey_moderation:
                 summary: "[PRO] OpenAI Content Moderation"


### PR DESCRIPTION
…spec

Adds a BASIC category example for default.requestParametersCheck in the create guardrail endpoint, covering tools and params configuration.